### PR TITLE
Form Bugs resolved

### DIFF
--- a/src/components/BasicForm.tsx
+++ b/src/components/BasicForm.tsx
@@ -169,9 +169,7 @@ export default function BasicForm({inputs, handleChange, handleCustomRadio, hand
 
         if(criteria === requirements)
             formHasErrors = false
-
         handleReRender()
-
     }
 
     function handleSubmit() {


### PR DESCRIPTION
Several problems were addressed:
- Changed the `calculate` button to make the blue get darker (for accessibility)
- Updated the imperial/metric button blue hover colors to match
- Separated handleForm() into handleForm() and handleError() to ensure only clicking the calculate button can advance to the next page
- useEffect was using imperialRider twice, not imperialRider and imperialBike - fixed.
- Reach and stack inputs were missing a ternary to handle border colors properly - fixed.
- When the form is about to be successfully submitted, I call the handle conversion functions to ensure the output page has access to imperial and metric inputs.

<b> This resolves #16 </b>

Aside from the button hover colors, the site looks exactly the same but behaves more predictably.