### PR TITLE
Make input form `tab`-able

### DIFF
--- a/src/components/BasicForm.tsx
+++ b/src/components/BasicForm.tsx
@@ -266,7 +266,8 @@ export default function BasicForm({inputs, handleChange, handleCustomComponent, 
                                 RIDER METRICS 
                         </Heading>
                         <Box >
-                            <Button 
+                            <Button
+                                tabIndex={-1}
                                 position="absolute" 
                                 right="65px"
                                 bottom="2px"
@@ -282,6 +283,7 @@ export default function BasicForm({inputs, handleChange, handleCustomComponent, 
                                     Metric
                             </Button>
                             <Button 
+                                tabIndex={-1}
                                 position="absolute" 
                                 right="10px" 
                                 bottom="2px"
@@ -445,6 +447,7 @@ export default function BasicForm({inputs, handleChange, handleCustomComponent, 
                             </Heading>
                             <Box >
                                 <Button 
+                                    tabIndex={-1}
                                     position="absolute" 
                                     right="65px" 
                                     bottom="2px"
@@ -460,6 +463,7 @@ export default function BasicForm({inputs, handleChange, handleCustomComponent, 
                                         Metric
                                 </Button>
                                 <Button 
+                                    tabIndex={-1}
                                     position="absolute" 
                                     right="10px" 
                                     bottom="2px"    

--- a/src/components/CustomRadio.tsx
+++ b/src/components/CustomRadio.tsx
@@ -1,4 +1,5 @@
 import { Box } from "@chakra-ui/react"
+import { KeyboardEvent } from "react"
 
 interface CustomRadioProps{
     title: string;
@@ -17,10 +18,17 @@ export default function CustomRadio(props: CustomRadioProps) {
     if(isError)
         borderColor = "brand.error"
         
+    function handleKeyPress(event: KeyboardEvent<HTMLImageElement>){
+        if (event.key === 'Enter')
+            handleCustomRadio(name, value)
+    }
+
     return(
         <Box as='label' title={title}>
             <Box
+                tabIndex={0}
                 onClick={() => handleCustomRadio(name, value)} 
+                onKeyPress={handleKeyPress}
                 bg="brand.darkGrey"
                 color={isChecked? "brand.white" : "brand.lightGrey"}
                 cursor='pointer'


### PR DESCRIPTION
- Made my custom radio component a `tab`-able component that is selected when the user hits `enter`.
- Removed `tab`-ability on the metric/imperial buttons