### PR TITLE
Make the Rider Info box (imperial/metric) consistant with the users choice

### DIFF
--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -34,6 +34,10 @@ interface FormProps{
         stackMM: string,
         bikeType: string
     };
+    imperialRider: boolean,
+    imperialBike: boolean,
+    handleImperialRider: () => void,
+    handleImperialBike: () => void,
     handleChange: (event: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLSelectElement>) => void;
     handleCustomComponent: (name: string, value: string) => void;
     handleRiderConversion: ({heightCMCalc, heightFootCalc, heightInchesCalc}: RiderConversionProps) => void;
@@ -44,9 +48,7 @@ interface FormProps{
 
 let formHasErrors = true
 
-export default function Form({inputs, handleChange, handleCustomComponent, handleRiderConversion, handleBikeConversion, handleFormCompletion, handleReRender}: FormProps) {
-    const [imperialRider, setImperialRider] = useState(true)
-    const [imperialBike, setImperialBike] = useState(false)
+export default function Form({inputs, imperialRider, imperialBike, handleImperialRider, handleImperialBike, handleChange, handleCustomComponent, handleRiderConversion, handleBikeConversion, handleFormCompletion, handleReRender}: FormProps) {
     const [showErrors, setShowErrors] = useState(false)
     let criteria = 0
     let requirements = 7
@@ -59,7 +61,7 @@ export default function Form({inputs, handleChange, handleCustomComponent, handl
     }, [imperialRider, imperialBike, inputs])
 
     function toggleRiderUnit() {
-        setImperialRider(prevImperialRider => !prevImperialRider)
+        handleImperialRider()
         if (imperialRider)
             requirements = 9
         else
@@ -68,7 +70,7 @@ export default function Form({inputs, handleChange, handleCustomComponent, handl
     }
 
     function toggleBikeUnit(){
-        setImperialBike(prevImperialBike => !prevImperialBike)
+        handleImperialBike()
         bikeStateConversion()
     }
 

--- a/src/components/Output/Output.tsx
+++ b/src/components/Output/Output.tsx
@@ -32,9 +32,11 @@ interface OutputProps{
         rearTirePSI: string,
         inserts: string,
     }
+    imperialRider: boolean,
+    imperialBike: boolean,
 }
 
-export default function Output({inputs, outputs}: OutputProps) {
+export default function Output({inputs, outputs, imperialRider, imperialBike}: OutputProps) {
     const [showSidePanel, setShowSidePanel] = useState(true)
     const [metricOutput, setMetricOutput] = useState(true)
 
@@ -66,13 +68,13 @@ export default function Output({inputs, outputs}: OutputProps) {
                                 <Text>Height</Text>
                             </GridItem>
                             <GridItem colSpan={1} w="100%" textAlign="right">
-                                <Text>{inputs.heightCM}cm</Text>
+                                <Text>{imperialRider? inputs.heightFeet + '\'' + inputs.heightInches + "\"" : inputs.heightCM + 'cm'}</Text>
                             </GridItem>
                             <GridItem colSpan={1} w="100%" textAlign="left">
                                 <Text>Weight</Text>
                             </GridItem>
                             <GridItem colSpan={1} w="100%" textAlign="right">
-                                <Text>{inputs.weightKG}kg</Text>
+                                <Text>{imperialRider? inputs.weightLB + 'lb' : inputs.weightKG + 'kg'}</Text>
                             </GridItem>
                             <GridItem colSpan={1} w="100%" textAlign="left">
                                 <Text>Handling</Text>
@@ -90,13 +92,13 @@ export default function Output({inputs, outputs}: OutputProps) {
                                 <Text>Reach</Text>
                             </GridItem>
                             <GridItem colSpan={1} w="100%" textAlign="right">
-                                <Text>{inputs.reachMM}mm</Text>
+                                <Text>{imperialBike? inputs.reachInches + '"' : inputs.reachMM + 'mm'}</Text>
                             </GridItem>
                             <GridItem colSpan={1} w="100%" textAlign="left">
                                 <Text>Stack</Text>
                             </GridItem>
                             <GridItem colSpan={1} w="100%" textAlign="right">
-                                <Text>{inputs.stackMM}mm</Text>
+                                <Text>{imperialBike? inputs.stackInches + '"' : inputs.stackMM + 'mm'}</Text>
                             </GridItem>
                             <GridItem colSpan={1} w="100%" textAlign="left">
                                 <Text>Bike Type</Text>

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -118,6 +118,8 @@ export default function Home() {
                     <Output 
                         inputs={inputs}
                         outputs={outputs}
+                        imperialRider={imperialRider}
+                        imperialBike={imperialBike}
                         />
                 </>  
                 }

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -11,6 +11,8 @@ import Algorithm from "../../algorithms/Algorithm/Algorithm"
 export default function Home() {
 
     let displayedComponent = "Form"
+    const [imperialRider, setImperialRider] = useState(true)
+    const [imperialBike, setImperialBike] = useState(false)
     const [reRender, setReRender] = useState(0)
     const [isFormComplete, setIsFormComplete] = useState(false)
     const [inputs, setInputs] = useState({
@@ -99,6 +101,10 @@ export default function Home() {
                 { displayedComponent === "Form" &&
                     <Form
                         inputs={inputs}
+                        imperialRider={imperialRider}
+                        imperialBike={imperialBike}
+                        handleImperialRider={() => setImperialRider( prevImperialRider => !prevImperialRider )}
+                        handleImperialBike={() => setImperialBike( prevImperialBike => !prevImperialBike )}
                         handleChange={handleChange}
                         handleCustomComponent={handleCustomComponent}
                         handleRiderConversion={handleRiderConversion}


### PR DESCRIPTION
Moved rider and bike metric/imperial state from the Form component to the Home component. This allowed the output page to render the rider info in the same units that the user chose. While doing this, I found on bug (issue #58) which was already in the codebase.

![image](https://user-images.githubusercontent.com/76227136/164791428-b708aa50-ec29-421d-af68-f36822754860.png)
<img width="240" alt="image" src="https://user-images.githubusercontent.com/76227136/164791547-249c103e-49eb-4626-8993-6f86ef3c6009.png">

