### PR TITLE
Resolve Form submission bug when rider chooses metric

### DIFF
--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -199,7 +199,7 @@ export default function Form({inputs, imperialRider, imperialBike, handleImperia
         }
 
 
-        if(criteria === requirements)
+        if(criteria >= requirements)
             formHasErrors = false
         handleReRender()
     }


### PR DESCRIPTION
This PR resolves issue #58. 

When the user changes from imperial to metric after completing the imperial height(feet) and height(inches), their `criteria` will be higher than the `requirements`. The form automatically converts the height(cm), so it now has additional information. This is not a problem, it is good to have additional information about the user. The bug was that the `handleErrors()` function expects less information to go to the Output page, but we have more than enough information, so we can change the inequality to `>=`. All other use cases are manually tested, and working as intended.