### PR TITLE
Fix Modal popup from landing outside of viewport

### DIFF
--- a/src/components/LearnMoreModal/LearnMoreModal.tsx
+++ b/src/components/LearnMoreModal/LearnMoreModal.tsx
@@ -24,7 +24,7 @@ export default function LearnMoreModal({id}: LeanMoreModalProps) {
                 > learn more 
             </Button>
         
-            <Modal isOpen={isOpen} onClose={onClose} isCentered>
+            <Modal isOpen={isOpen} onClose={onClose} scrollBehavior="outside">
                 <ModalOverlay />
                 <ModalContent bg='brand.darkGrey'>
                     <ModalHeader textDecoration="underline" color="brand.white">{data.title}</ModalHeader>


### PR DESCRIPTION
Modal was using a centered prop, which doesn't take into account the height of the modal relative to the screen size. Removing this and setting the scroll to outside allows for full modal visibility in mobile landscape/portrait and in web. Further refinement to come eventually.

**New** (scrollable)
![image](https://user-images.githubusercontent.com/76227136/179381209-357883be-952a-4a92-b0d8-e3d304f2d0f5.png)

**Old**
<img width="416" alt="image" src="https://user-images.githubusercontent.com/76227136/179381226-14b2f093-354e-4066-a13e-3edd3ff08a97.png">
