### PR TITLE
Improve CSS Transitions + Icons

### DIFF
--- a/src/components/CustomRadio/CustomRadio.tsx
+++ b/src/components/CustomRadio/CustomRadio.tsx
@@ -23,18 +23,18 @@ export default function CustomRadio(props: CustomRadioProps): JSX.Element {
                 onClick={() => handleCustomRadio(name, value)} 
                 onKeyPress={handleKeyPress}
                 _hover={{borderColor: "#CBD5E0"}}
+                _focus={{borderColor: "brand.blue"}}
                 bg="brand.darkGrey"
                 color={isChecked? "brand.white" : "brand.lightGrey"}
                 cursor='pointer'
-                border="1px solid #AAAAAA"
+                border="1px solid transparent"
                 borderColor={borderColor}
-                borderRadius='3px'
                 boxShadow='md'
                 textAlign="center"
                 px={[3, 3]}
                 py={2}
                 >
-                {title}
+                    {title}
             </Box>
         </Box>
     );

--- a/src/components/CustomRadio/CustomRadio.tsx
+++ b/src/components/CustomRadio/CustomRadio.tsx
@@ -22,7 +22,7 @@ export default function CustomRadio(props: CustomRadioProps): JSX.Element {
                 tabIndex={0}
                 onClick={() => handleCustomRadio(name, value)} 
                 onKeyPress={handleKeyPress}
-                _hover={{borderColor: "#CBD5E0"}}
+                _hover={{borderColor: "brand.hoverGrey"}}
                 _focus={{borderColor: "brand.blue"}}
                 bg="brand.darkGrey"
                 color={isChecked? "brand.white" : "brand.lightGrey"}

--- a/src/components/CustomRadio/CustomRadio.tsx
+++ b/src/components/CustomRadio/CustomRadio.tsx
@@ -22,6 +22,7 @@ export default function CustomRadio(props: CustomRadioProps): JSX.Element {
                 tabIndex={0}
                 onClick={() => handleCustomRadio(name, value)} 
                 onKeyPress={handleKeyPress}
+                _hover={{borderColor: "#CBD5E0"}}
                 bg="brand.darkGrey"
                 color={isChecked? "brand.white" : "brand.lightGrey"}
                 cursor='pointer'

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -333,7 +333,6 @@ export default function Form({
                         </Heading>
                         <Box >
                             <Button
-                                tabIndex={-1}
                                 position="absolute" 
                                 right="65px"
                                 bottom="2px"
@@ -345,11 +344,13 @@ export default function Form({
                                 onClick={toggleRiderUnit}
                                 _hover={ imperialRider? { bg: "brand.lightGrey", filter: "brightness(110%)"}
                                                       : {bg: "brand.blue", filter: "brightness(90%)"} }
+                                _active={{ bg: imperialRider? "brand.blue" : "brand.lightGrey",
+                                    color: imperialRider? "brand.white" : "brand.black",
+                                }}
                                 >
                                     Metric
                             </Button>
                             <Button 
-                                tabIndex={-1}
                                 position="absolute" 
                                 right="10px" 
                                 bottom="2px"
@@ -360,9 +361,12 @@ export default function Form({
                                 bg={imperialRider? "brand.blue": "brand.lightGrey"} 
                                 color={imperialRider? "brand.white": "brand.black"}
                                 onClick={toggleRiderUnit}
+                                data-testid="imperialRiderButton"
                                 _hover={ imperialRider? {bg: "brand.blue", filter: "brightness(90%)"}
                                                      : { bg: "brand.lightGrey", filter: "brightness(110%)"} }
-                                data-testid="imperialRiderButton"
+                                _active={{ bg: imperialRider? "brand.lightGrey" : "brand.blue",
+                                    color: imperialRider? "brand.black" : "brand.white",
+                                }}  
                                 >
                                     Imperial
                             </Button>
@@ -513,7 +517,6 @@ export default function Form({
                             </Heading>
                             <Box >
                                 <Button 
-                                    tabIndex={-1}
                                     position="absolute" 
                                     right="65px" 
                                     bottom="2px"
@@ -525,11 +528,13 @@ export default function Form({
                                     onClick={toggleBikeUnit}
                                     _hover={ imperialBike? { bg: "brand.lightGrey", filter: "brightness(110%)" }
                                     : {bg: "brand.blue", filter: "brightness(90%)"} }
+                                    _active={{ bg: imperialBike? "brand.blue" : "brand.lightGrey",
+                                        color: imperialBike? "brand.white" : "brand.black",
+                                    }}                                    
                                     >
                                         Metric
                                 </Button>
                                 <Button 
-                                    tabIndex={-1}
                                     position="absolute" 
                                     right="10px" 
                                     bottom="2px"    
@@ -540,9 +545,12 @@ export default function Form({
                                     color={imperialBike? "brand.white": "brand.black"}
                                     bg={imperialBike? "brand.blue": "brand.lightGrey"} 
                                     onClick={toggleBikeUnit}
+                                    data-testid="imperialBikeButton"
                                     _hover={ imperialBike? {bg: "brand.blue", filter: "brightness(90%)"}
                                                           : { bg: "brand.lightGrey", filter: "brightness(110%)"} }
-                                    data-testid="imperialBikeButton"
+                                    _active={{ bg: imperialBike? "brand.lightGrey" : "brand.blue",
+                                        color: imperialBike? "brand.black" : "brand.white",
+                                    }}  
                                     >
                                         Imperial
                                 </Button>
@@ -637,6 +645,7 @@ export default function Form({
                             borderRadius='50px'
                             onClick={handleSubmit}
                             _hover={{bg: "brand.blue", filter: "brightness(90%)"}}
+                            _active={{ bg: "brand.blue"}}
                             > 
                                 Calculate 
                         </Button>

--- a/src/components/LearnMoreModal/LearnMoreModal.tsx
+++ b/src/components/LearnMoreModal/LearnMoreModal.tsx
@@ -29,6 +29,7 @@ export default function LearnMoreModal({id}: LeanMoreModalProps): JSX.Element {
                 color="brand.white" 
                 my={2}
                 _hover={{bg: "brand.blue"}}
+                _active={{bg: "brand.blue"}}
                 > learn more 
             </Button>
         

--- a/src/components/Output/Output.tsx
+++ b/src/components/Output/Output.tsx
@@ -48,6 +48,7 @@ export default function Output({inputs, outputs, imperialRider, imperialBike, ha
                                color={"brand.white"}
                                bg={"brand.blue"} 
                                _hover={{bg: "brand.blue", filter: "brightness(90%)"}}
+                               _active={{bg: "brand.blue", filter: "brightness(90%)"}}
                                alignSelf={"flex-end"}
                             >
                                 Edit
@@ -128,8 +129,12 @@ export default function Output({inputs, outputs, imperialRider, imperialBike, ha
                                     color={metricOutput? "brand.white" : "brand.black"}
                                     bg={metricOutput? "brand.blue" : "brand.lightGrey"} 
                                     onClick={() => setMetricOutput(prevMetricOutput => !prevMetricOutput)}
-                                    _hover={metricOutput? {bg: "brand.blue", filter: "brightness(90%)"}
-                                                        : { bg: "brand.lightGrey", filter: "brightness(110%)"} }
+                                    _hover={ metricOutput? {bg: "brand.blue", filter: "brightness(90%)"}
+                                                        : { bg: "brand.lightGrey", filter: "brightness(110%)"} 
+                                        }
+                                    _active={{ bg: metricOutput? "brand.lightGrey" : "brand.blue",
+                                        color: metricOutput? "brand.black" : "brand.white",
+                                    }} 
                                     >
                                         Metric
                                 </Button>
@@ -144,8 +149,12 @@ export default function Output({inputs, outputs, imperialRider, imperialBike, ha
                                     bg={metricOutput? "brand.lightGrey" : "brand.blue"} 
                                     color={metricOutput? "brand.black" : "brand.white"}
                                     onClick={() => setMetricOutput(prevMetricOutput => !prevMetricOutput)}
-                                    _hover={metricOutput? { bg: "brand.lightGrey", filter: "brightness(110%)"}
-                                                        : {bg: "brand.blue", filter: "brightness(90%)"} }
+                                    _hover={ metricOutput? { bg: "brand.lightGrey", filter: "brightness(110%)"}
+                                                        : {bg: "brand.blue", filter: "brightness(90%)"} 
+                                    }
+                                    _active={{ bg: metricOutput? "brand.blue" : "brand.lightGrey",
+                                        color: metricOutput? "brand.white" : "brand.black",
+                                    }} 
                                     >
                                         Imperial
                                 </Button>

--- a/src/pages/Help/Help.tsx
+++ b/src/pages/Help/Help.tsx
@@ -97,7 +97,7 @@ export default function Help(): JSX.Element {
                             </InputGroup>
                             <Icon 
                                 onClick={() => setShowPanel((prevShowPanel) => !prevShowPanel )}
-                                as={FaChevronCircleRight}  
+                                as={FaChevronCircleLeft}  
                                 w={5} h={5}
                                 cursor='pointer'
                             />
@@ -164,7 +164,7 @@ export default function Help(): JSX.Element {
                         position='sticky'
                         top="0.5rem"
                         onClick={() => setShowPanel((prevShowPanel) => !prevShowPanel )}
-                        as={FaChevronCircleLeft} 
+                        as={FaChevronCircleRight} 
                         w={5} h={5} mr='2rem'
                         cursor='pointer'
                     />

--- a/src/pages/Help/Help.tsx
+++ b/src/pages/Help/Help.tsx
@@ -16,8 +16,8 @@ import {FaSearch,
     FaHandsHelping, 
     FaTools, 
     FaBicycle, 
-    FaRegWindowClose, 
-    FaBars
+    FaChevronCircleLeft,
+    FaChevronCircleRight
 } from "react-icons/fa";
 
 export default function Help(): JSX.Element {
@@ -92,13 +92,14 @@ export default function Help(): JSX.Element {
                                     mb='0.5rem'
                                 />
                                 <InputRightElement>
-                                    <Icon as={FaSearch} w={5} h={5}/>
+                                    <Icon as={FaSearch} w={5} h={5} cursor='pointer'/>
                                 </InputRightElement>
                             </InputGroup>
                             <Icon 
                                 onClick={() => setShowPanel((prevShowPanel) => !prevShowPanel )}
-                                as={FaRegWindowClose} 
+                                as={FaChevronCircleRight}  
                                 w={5} h={5}
+                                cursor='pointer'
                             />
                         </HStack>
 
@@ -163,8 +164,9 @@ export default function Help(): JSX.Element {
                         position='sticky'
                         top="0.5rem"
                         onClick={() => setShowPanel((prevShowPanel) => !prevShowPanel )}
-                        as={FaBars} 
+                        as={FaChevronCircleLeft} 
                         w={5} h={5} mr='2rem'
+                        cursor='pointer'
                     />
                 }
                 <VStack 

--- a/src/styling/theme.ts
+++ b/src/styling/theme.ts
@@ -5,6 +5,7 @@ export const theme = extendTheme({
         brand: {
             lightGrey: "#BDBDBD",
             darkGrey: "#303638",
+            hoverGrey: "#CBD5E0",
             blue: "#5B7BC0",
             white: "#FFFDFA",
             black: "black",


### PR DESCRIPTION
# Form Page
- Override the ChakraUI default _focus_ behaviour on all buttons to be consistent with branding
  - Most notably, get rid of the white background 
- Made Custom Radio Buttons border change colour _on hover_ to be consistent with the rest of the form
- Made the Custom Radio Buttons have a blue border _on focus_ to be consistent with the rest of the form
- Allow tabbing to/from the metric/imperial buttons

<img width="278" alt="image" src="https://user-images.githubusercontent.com/76227136/208487256-9522842d-cb4e-4e1b-8919-ff76c11c760f.png">

# Output Page
- Override the ChakraUI default _focus_ behaviour on all buttons to be consistent with branding
  - Most notably, get rid of the white background 
  
<img width="554" alt="image" src="https://user-images.githubusercontent.com/76227136/208489219-0967d757-ad9a-4890-b5ae-9048beef8562.png">


# Help Page
- Add cursor behaviour (pointer) to the menu open and close icons
- Replace hamburger and close icons with chevron icons to better depict their purpose.

<img width="743" alt="image" src="https://user-images.githubusercontent.com/76227136/208331233-44dd7236-bd68-469f-8371-bc7841a6ff2e.png">

<img width="740" alt="image" src="https://user-images.githubusercontent.com/76227136/208331246-aff5fa08-71fb-45fa-b52c-7cd58a9d79c5.png">
