### PR TITLE
Help Page Scroll Bug

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -41,7 +41,8 @@ export default function Header(): JSX.Element {
 			w='100%'
 			position='fixed'
 			top='0'
-			bg='brand.headerGradient'
+			// bg='brand.headerGradient'
+			bg='brand.black'
 			color='brand.white'
 			zIndex='200'>
 			<Container maxW='50rem' p='0px'>

--- a/src/pages/Help/Help.tsx
+++ b/src/pages/Help/Help.tsx
@@ -41,8 +41,14 @@ export default function Help(): JSX.Element {
 	}
 
 	return (
-		<Container w='100%' maxW='64rem' pr='2rem'>
-			<HStack h='calc(100vh - 50px)' py='1rem' spacing='0px' align='start'>
+		<Container
+			h='100%'
+			// h='calc(100% - 50px)'
+			w='100%'
+			maxW='64rem'
+			pr='2rem'
+			bg='cyan'>
+			<HStack h='100%' spacing='0px' align='start' bg='purple'>
 				{showPanel && (
 					<VStack
 						alignItems='flex-start'

--- a/src/pages/Help/Help.tsx
+++ b/src/pages/Help/Help.tsx
@@ -66,6 +66,7 @@ export default function Help(): JSX.Element {
 						spacing='0.6rem'
 						w={width < smallScreen ? '100vw' : '50%'}
 						h='100%'
+						pt='50px'
 						pr={width < smallScreen ? '0rem' : '1.5rem'}
 						css={{
 							'&::-webkit-scrollbar': {
@@ -180,6 +181,7 @@ export default function Help(): JSX.Element {
 						onClick={() => setShowPanel((prevShowPanel) => !prevShowPanel)}
 						position='sticky'
 						top='0.5rem'
+						mt='50px'
 						as={FaChevronCircleRight}
 						w={5}
 						h={5}
@@ -192,6 +194,7 @@ export default function Help(): JSX.Element {
 					overflow='scroll'
 					w={width < smallScreen ? (showPanel ? '0vw' : '100vw') : '90%'}
 					h='100%'
+					// r='2rem' TODO JOHN - Add this to better center help page content
 					css={{
 						'&::-webkit-scrollbar': {
 							display: 'none',

--- a/src/pages/Help/Help.tsx
+++ b/src/pages/Help/Help.tsx
@@ -41,32 +41,20 @@ export default function Help(): JSX.Element {
 	}
 
 	return (
-		<Container
-			h='100%'
-			// h='calc(100% - 50px)'
-			position='sticky'
-			top='50px'
-			w='100%'
-			maxW='64rem'
-			pr='2rem'
-			// mt='1rem'
-			bg='green'>
-			<HStack
-				h='100%'
-				spacing='0px'
-				align='start'
-				bg='purple'
-				// position='sticky'
-				// top='50px'
-			>
+		<Container h='100%' position='sticky' top='50px' w='100%' maxW='64rem'>
+			<HStack h='100%' spacing='0px' align='start'>
 				{showPanel && (
 					<VStack
 						alignItems='flex-start'
 						overflow='scroll'
+						position='sticky'
+						top='100px'
+						mx='0px'
+						pl='1rem'
 						spacing='0.6rem'
 						w={width < smallScreen ? '100vw' : '50%'}
 						h='100%'
-						pt='50px'
+						pt={width < smallScreen ? '50px' : '0px'}
 						pr={width < smallScreen ? '0rem' : '1.5rem'}
 						css={{
 							'&::-webkit-scrollbar': {
@@ -81,7 +69,6 @@ export default function Help(): JSX.Element {
 							overflow='clipped'
 							opacity={1}
 							w='100%'
-							// color='red'
 							pt='1rem'>
 							<Link
 								onClick={closePanelForSmallScreen}
@@ -96,7 +83,6 @@ export default function Help(): JSX.Element {
 								as={FaChevronCircleLeft}
 								w={5}
 								h={5}
-								cursor='pointer'
 							/>
 						</HStack>
 
@@ -181,7 +167,7 @@ export default function Help(): JSX.Element {
 						onClick={() => setShowPanel((prevShowPanel) => !prevShowPanel)}
 						position='sticky'
 						top='0.5rem'
-						mt='50px'
+						mt={width < smallScreen ? '50px' : '0px'}
 						as={FaChevronCircleRight}
 						w={5}
 						h={5}
@@ -192,8 +178,10 @@ export default function Help(): JSX.Element {
 				<VStack
 					alignItems={'flex-start'}
 					overflow='scroll'
-					w={width < smallScreen ? (showPanel ? '0vw' : '100vw') : '90%'}
+					w={width < smallScreen ? (showPanel ? '0vw' : '100vw') : '87%'}
 					h='100%'
+					mr={!showPanel ? '0rem' : '2rem'}
+					pr={!showPanel ? '2rem' : '0rem'}
 					// r='2rem' TODO JOHN - Add this to better center help page content
 					css={{
 						'&::-webkit-scrollbar': {
@@ -202,7 +190,11 @@ export default function Help(): JSX.Element {
 						overflowStyle: 'none',
 						scrollbarWidth: 'none',
 					}}>
-					<Heading as='h1' fontSize={'4xl'} id='usingTheTuningGuide' pt='50px'>
+					<Heading
+						as='h1'
+						fontSize={'4xl'}
+						id='usingTheTuningGuide'
+						pt={width < smallScreen ? '50px' : '0px'}>
 						Using The Tuning Guide
 					</Heading>
 					<Divider />
@@ -219,7 +211,11 @@ export default function Help(): JSX.Element {
 						direct you, the help page exists to teach you the principles behind
 						its decisions.
 					</Text>
-					<Heading as='h1' fontSize={'4xl'} id='understandingInputs' pt='50px'>
+					<Heading
+						as='h1'
+						fontSize={'4xl'}
+						id='understandingInputs'
+						pt={width < smallScreen ? '50px' : '0px'}>
 						Understanding Inputs
 					</Heading>
 					<Divider />
@@ -227,7 +223,7 @@ export default function Help(): JSX.Element {
 						as='h2'
 						fontSize={'2xl'}
 						id='riderSize'
-						pt='50px'
+						pt={width < smallScreen ? '50px' : '0px'}
 						fontWeight={'500'}
 						textDecoration='underline'
 						textDecorationThickness={'.1rem'}
@@ -289,7 +285,7 @@ export default function Help(): JSX.Element {
 						as='h2'
 						fontSize={'2xl'}
 						id='handling'
-						pt='50px'
+						pt={width < smallScreen ? '50px' : '0px'}
 						fontWeight={'500'}
 						textDecoration='underline'
 						textDecorationThickness={'.1rem'}
@@ -311,7 +307,7 @@ export default function Help(): JSX.Element {
 						as='h2'
 						fontSize={'2xl'}
 						id='skillLevel'
-						pt='50px'
+						pt={width < smallScreen ? '50px' : '0px'}
 						fontWeight={'500'}
 						textDecoration='underline'
 						textDecorationThickness={'.1rem'}
@@ -336,7 +332,7 @@ export default function Help(): JSX.Element {
 						as='h2'
 						fontSize={'2xl'}
 						id='reach'
-						pt='50px'
+						pt={width < smallScreen ? '50px' : '0px'}
 						fontWeight={'500'}
 						textDecoration='underline'
 						textDecorationThickness={'.1rem'}
@@ -361,7 +357,7 @@ export default function Help(): JSX.Element {
 						as='h2'
 						fontSize={'2xl'}
 						id='stack'
-						pt='50px'
+						pt={width < smallScreen ? '50px' : '0px'}
 						fontWeight={'500'}
 						textDecoration='underline'
 						textDecorationThickness={'.1rem'}
@@ -380,7 +376,7 @@ export default function Help(): JSX.Element {
 						as='h2'
 						fontSize={'2xl'}
 						id='bikeType'
-						pt='50px'
+						pt={width < smallScreen ? '50px' : '0px'}
 						fontWeight={'500'}
 						textDecoration='underline'
 						textDecorationThickness={'.1rem'}
@@ -400,7 +396,11 @@ export default function Help(): JSX.Element {
 						trail bike like an enduro bike, you will likely want to choose the
 						Enduro bike option.
 					</Text>
-					<Heading as='h1' fontSize={'4xl'} id='yourSettings' pt='50px'>
+					<Heading
+						as='h1'
+						fontSize={'4xl'}
+						id='yourSettings'
+						pt={width < smallScreen ? '50px' : '0px'}>
 						Your Settings
 					</Heading>
 					<Divider />
@@ -419,7 +419,7 @@ export default function Help(): JSX.Element {
 						as='h2'
 						fontSize={'2xl'}
 						id='handlebarWidth'
-						pt='50px'
+						pt={width < smallScreen ? '50px' : '0px'}
 						fontWeight={'500'}
 						textDecoration='underline'
 						textDecorationThickness={'.1rem'}
@@ -475,7 +475,7 @@ export default function Help(): JSX.Element {
 						as='h2'
 						fontSize={'2xl'}
 						id='handlebarRise'
-						pt='50px'
+						pt={width < smallScreen ? '50px' : '0px'}
 						fontWeight={'500'}
 						textDecoration='underline'
 						textDecorationThickness={'.1rem'}
@@ -500,7 +500,7 @@ export default function Help(): JSX.Element {
 						as='h2'
 						fontSize={'2xl'}
 						id='stemLength'
-						pt='50px'
+						pt={width < smallScreen ? '50px' : '0px'}
 						fontWeight={'500'}
 						textDecoration='underline'
 						textDecorationThickness={'.1rem'}
@@ -531,7 +531,7 @@ export default function Help(): JSX.Element {
 						as='h2'
 						fontSize={'2xl'}
 						id='stemSpacers'
-						pt='50px'
+						pt={width < smallScreen ? '50px' : '0px'}
 						fontWeight={'500'}
 						textDecoration='underline'
 						textDecorationThickness={'.1rem'}
@@ -572,7 +572,7 @@ export default function Help(): JSX.Element {
 						as='h2'
 						fontSize={'2xl'}
 						id='tirePressures'
-						pt='50px'
+						pt={width < smallScreen ? '50px' : '0px'}
 						fontWeight={'500'}
 						textDecoration='underline'
 						textDecorationThickness={'.1rem'}
@@ -595,7 +595,7 @@ export default function Help(): JSX.Element {
 						as='h2'
 						fontSize={'2xl'}
 						id='tireInserts'
-						pt='50px'
+						pt={width < smallScreen ? '50px' : '0px'}
 						fontWeight={'500'}
 						textDecoration='underline'
 						textDecorationThickness={'.1rem'}

--- a/src/pages/Help/Help.tsx
+++ b/src/pages/Help/Help.tsx
@@ -45,9 +45,11 @@ export default function Help(): JSX.Element {
 			h='100%'
 			// h='calc(100% - 50px)'
 			position='sticky'
+			top='0'
 			w='100%'
 			maxW='64rem'
 			pr='2rem'
+			mt='1rem'
 			// bg='cyan'
 		>
 			<HStack
@@ -55,7 +57,8 @@ export default function Help(): JSX.Element {
 				spacing='0px'
 				align='start'
 				// bg='purple'
-				position='sticky'>
+				position='sticky'
+				top='0'>
 				{showPanel && (
 					<VStack
 						alignItems='flex-start'

--- a/src/pages/Help/Help.tsx
+++ b/src/pages/Help/Help.tsx
@@ -80,6 +80,7 @@ export default function Help(): JSX.Element {
 							overflow='clipped'
 							opacity={1}
 							w='100%'
+							// color='red'
 							pt='1rem'>
 							<Link
 								onClick={closePanelForSmallScreen}
@@ -198,7 +199,7 @@ export default function Help(): JSX.Element {
 						overflowStyle: 'none',
 						scrollbarWidth: 'none',
 					}}>
-					<Heading as='h1' fontSize={'4xl'} id='usingTheTuningGuide'>
+					<Heading as='h1' fontSize={'4xl'} id='usingTheTuningGuide' pt='50px'>
 						Using The Tuning Guide
 					</Heading>
 					<Divider />
@@ -215,7 +216,7 @@ export default function Help(): JSX.Element {
 						direct you, the help page exists to teach you the principles behind
 						its decisions.
 					</Text>
-					<Heading as='h1' fontSize={'4xl'} id='understandingInputs'>
+					<Heading as='h1' fontSize={'4xl'} id='understandingInputs' pt='50px'>
 						Understanding Inputs
 					</Heading>
 					<Divider />
@@ -223,6 +224,7 @@ export default function Help(): JSX.Element {
 						as='h2'
 						fontSize={'2xl'}
 						id='riderSize'
+						pt='50px'
 						fontWeight={'500'}
 						textDecoration='underline'
 						textDecorationThickness={'.1rem'}
@@ -284,6 +286,7 @@ export default function Help(): JSX.Element {
 						as='h2'
 						fontSize={'2xl'}
 						id='handling'
+						pt='50px'
 						fontWeight={'500'}
 						textDecoration='underline'
 						textDecorationThickness={'.1rem'}
@@ -305,6 +308,7 @@ export default function Help(): JSX.Element {
 						as='h2'
 						fontSize={'2xl'}
 						id='skillLevel'
+						pt='50px'
 						fontWeight={'500'}
 						textDecoration='underline'
 						textDecorationThickness={'.1rem'}
@@ -329,6 +333,7 @@ export default function Help(): JSX.Element {
 						as='h2'
 						fontSize={'2xl'}
 						id='reach'
+						pt='50px'
 						fontWeight={'500'}
 						textDecoration='underline'
 						textDecorationThickness={'.1rem'}
@@ -353,6 +358,7 @@ export default function Help(): JSX.Element {
 						as='h2'
 						fontSize={'2xl'}
 						id='stack'
+						pt='50px'
 						fontWeight={'500'}
 						textDecoration='underline'
 						textDecorationThickness={'.1rem'}
@@ -371,6 +377,7 @@ export default function Help(): JSX.Element {
 						as='h2'
 						fontSize={'2xl'}
 						id='bikeType'
+						pt='50px'
 						fontWeight={'500'}
 						textDecoration='underline'
 						textDecorationThickness={'.1rem'}
@@ -390,7 +397,7 @@ export default function Help(): JSX.Element {
 						trail bike like an enduro bike, you will likely want to choose the
 						Enduro bike option.
 					</Text>
-					<Heading as='h1' fontSize={'4xl'} id='yourSettings'>
+					<Heading as='h1' fontSize={'4xl'} id='yourSettings' pt='50px'>
 						Your Settings
 					</Heading>
 					<Divider />
@@ -409,6 +416,7 @@ export default function Help(): JSX.Element {
 						as='h2'
 						fontSize={'2xl'}
 						id='handlebarWidth'
+						pt='50px'
 						fontWeight={'500'}
 						textDecoration='underline'
 						textDecorationThickness={'.1rem'}
@@ -464,6 +472,7 @@ export default function Help(): JSX.Element {
 						as='h2'
 						fontSize={'2xl'}
 						id='handlebarRise'
+						pt='50px'
 						fontWeight={'500'}
 						textDecoration='underline'
 						textDecorationThickness={'.1rem'}
@@ -488,6 +497,7 @@ export default function Help(): JSX.Element {
 						as='h2'
 						fontSize={'2xl'}
 						id='stemLength'
+						pt='50px'
 						fontWeight={'500'}
 						textDecoration='underline'
 						textDecorationThickness={'.1rem'}
@@ -518,6 +528,7 @@ export default function Help(): JSX.Element {
 						as='h2'
 						fontSize={'2xl'}
 						id='stemSpacers'
+						pt='50px'
 						fontWeight={'500'}
 						textDecoration='underline'
 						textDecorationThickness={'.1rem'}
@@ -536,7 +547,7 @@ export default function Help(): JSX.Element {
 						<br />
 						Stem spacers are one of the most overlooked adjustments riders make.
 						As discussed under the{' '}
-						<Link href='#handlebarRise' textDecoration='underline'>
+						<Link href='#handlebarRise' textDecoration='underline' pt='16px'>
 							handlebar rise
 						</Link>{' '}
 						section, altering the number of stem spaces can adjust your reach*
@@ -558,6 +569,7 @@ export default function Help(): JSX.Element {
 						as='h2'
 						fontSize={'2xl'}
 						id='tirePressures'
+						pt='50px'
 						fontWeight={'500'}
 						textDecoration='underline'
 						textDecorationThickness={'.1rem'}
@@ -580,6 +592,7 @@ export default function Help(): JSX.Element {
 						as='h2'
 						fontSize={'2xl'}
 						id='tireInserts'
+						pt='50px'
 						fontWeight={'500'}
 						textDecoration='underline'
 						textDecorationThickness={'.1rem'}

--- a/src/pages/Help/Help.tsx
+++ b/src/pages/Help/Help.tsx
@@ -45,20 +45,20 @@ export default function Help(): JSX.Element {
 			h='100%'
 			// h='calc(100% - 50px)'
 			position='sticky'
-			top='0'
+			top='50px'
 			w='100%'
 			maxW='64rem'
 			pr='2rem'
-			mt='1rem'
-			// bg='cyan'
-		>
+			// mt='1rem'
+			bg='green'>
 			<HStack
 				h='100%'
 				spacing='0px'
 				align='start'
-				// bg='purple'
-				position='sticky'
-				top='0'>
+				bg='purple'
+				// position='sticky'
+				// top='50px'
+			>
 				{showPanel && (
 					<VStack
 						alignItems='flex-start'
@@ -79,7 +79,8 @@ export default function Help(): JSX.Element {
 							top='0rem'
 							overflow='clipped'
 							opacity={1}
-							w='100%'>
+							w='100%'
+							pt='1rem'>
 							<Link
 								onClick={closePanelForSmallScreen}
 								href='#usingTheTuningGuide'>
@@ -175,9 +176,9 @@ export default function Help(): JSX.Element {
 				)}
 				{!showPanel && (
 					<Icon
-						top='0.5rem'
 						onClick={() => setShowPanel((prevShowPanel) => !prevShowPanel)}
 						position='sticky'
+						top='0.5rem'
 						as={FaChevronCircleRight}
 						w={5}
 						h={5}

--- a/src/pages/Help/Help.tsx
+++ b/src/pages/Help/Help.tsx
@@ -44,11 +44,18 @@ export default function Help(): JSX.Element {
 		<Container
 			h='100%'
 			// h='calc(100% - 50px)'
+			position='sticky'
 			w='100%'
 			maxW='64rem'
 			pr='2rem'
-			bg='cyan'>
-			<HStack h='100%' spacing='0px' align='start' bg='purple'>
+			// bg='cyan'
+		>
+			<HStack
+				h='100%'
+				spacing='0px'
+				align='start'
+				// bg='purple'
+				position='sticky'>
 				{showPanel && (
 					<VStack
 						alignItems='flex-start'
@@ -167,6 +174,7 @@ export default function Help(): JSX.Element {
 					<Icon
 						top='0.5rem'
 						onClick={() => setShowPanel((prevShowPanel) => !prevShowPanel)}
+						position='sticky'
 						as={FaChevronCircleRight}
 						w={5}
 						h={5}


### PR DESCRIPTION
I think I've gotten to the bottom of this mobile-only bug. 

- When the Chrome URL banner appears on mobile, the chevron icon will disappear after being clicked, likely because it is hidden under the header
- When the Chrome URL banner does not appear on mobile (which is caused by opening the MtbTG from the mobile homescreen shortcut) the menu operates as expeted.
- You cannot control the Chrome banner directly from my understanding.

